### PR TITLE
Support APP_CONFIG_PATH env var for configurable app-config location

### DIFF
--- a/auth-setup.ts
+++ b/auth-setup.ts
@@ -4,7 +4,8 @@ import * as path from 'path';
 
 const parentConfigPath = path.join(__dirname, '..', 'app-config.json');
 const localConfigPath = path.join(__dirname, 'app-config.json');
-const configPath = fs.existsSync(parentConfigPath) ? parentConfigPath : localConfigPath;
+const configPath = process.env.APP_CONFIG_PATH
+  || (fs.existsSync(parentConfigPath) ? parentConfigPath : localConfigPath);
 const storageStatePath = path.join(__dirname, '.auth-state.json');
 
 setup('authenticate', async ({ page }) => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig } from '@playwright/test';
 import * as fs from 'fs';
 
-// Load app config if present (check parent dir first, then local)
+// Load app config — APP_CONFIG_PATH env var takes priority, then parent dir, then local
 const parentConfigPath = '../app-config.json';
 const localConfigPath = './app-config.json';
-const appConfigPath = fs.existsSync(parentConfigPath) ? parentConfigPath : localConfigPath;
-const appConfig = fs.existsSync(appConfigPath)
-  ? JSON.parse(fs.readFileSync(appConfigPath, 'utf8'))
+const resolvedConfigPath = process.env.APP_CONFIG_PATH
+  || (fs.existsSync(parentConfigPath) ? parentConfigPath : localConfigPath);
+const appConfig = fs.existsSync(resolvedConfigPath)
+  ? JSON.parse(fs.readFileSync(resolvedConfigPath, 'utf8'))
   : {};
 
 const baseURL = process.env.BASE_URL || appConfig.baseURL || 'http://localhost:5173';


### PR DESCRIPTION
Allows apps to store app-config.json outside the project root (e.g. in a playwright/ subdirectory) by exporting APP_CONFIG_PATH before running tests, consistent with how BASE_URL is already overridable.