### PR TITLE
Inspector: surface eventArgs.description in handler:start title

### DIFF
--- a/xs-diff.html
+++ b/xs-diff.html
@@ -2455,11 +2455,23 @@
           const label = preferredStart.componentLabel || "";
           const uid = preferredStart.uid || "";
           const event = preferredStart.eventName || "";
+
+          // Optional human-readable summary contributed by the component:
+          // any eventArg that's an object with a string `description` field is
+          // surfaced after the type/event identifier. Lets components like
+          // xmlui-dnd-list say "Toronto moved from position 1 to position 3"
+          // without the Inspector having to know the component's semantics.
+          const eventArgs = Array.isArray(preferredStart.eventArgs) ? preferredStart.eventArgs : [];
+          const description = eventArgs
+            .map((a) => (a && typeof a === "object" && typeof a.description === "string") ? a.description : null)
+            .find((d) => d);
+
           const parts = [];
           if (type) parts.push(type);
           if (label) parts.push(`"${label}"`);
           else if (uid && uid !== event) parts.push(uid);
           if (event) parts.push(event);
+          if (description) parts.push(`— ${description}`);
           componentText = parts.join(" ");
         } else {
           const interaction = traceEntries.find((e) => e.kind === "interaction");
@@ -4723,6 +4735,7 @@
               perfTs: opts.perfTs || TestFramework.perfTs(),
               ownerFileId: opts.fileId,
               handlerCode: opts.handlerCode,
+              eventArgs: opts.eventArgs,
             };
           },
 
@@ -5928,6 +5941,47 @@
           ];
           const summary = buildTraceSummary(events);
           assertTrue(summary.behavioralEventCount > 0, "Native events should count as behavioral");
+        });
+
+        test("Native Events", "handler:start eventArgs.description appended to title", () => {
+          const traceId = TestFramework.interactionTraceId();
+          const events = [
+            TestFramework.events.handlerStart("reorder", {
+              traceId,
+              componentType: "XMLUIDndList.DndItems",
+              perfTs: 100,
+              eventArgs: [
+                ["toronto", "albany", "keene"],
+                {
+                  item: "keene",
+                  fromIndex: 2,
+                  toIndex: 0,
+                  description: "keene moved from position 3 to position 1",
+                },
+              ],
+            }),
+          ];
+          const summary = buildTraceSummary(events);
+          assertContains(summary.componentText, "XMLUIDndList.DndItems", "Should include component type");
+          assertContains(summary.componentText, "reorder", "Should include event name");
+          assertContains(summary.componentText, "keene moved from position 3 to position 1", "Should include eventArgs description");
+        });
+
+        test("Native Events", "handler:start without eventArgs.description omits suffix", () => {
+          const traceId = TestFramework.interactionTraceId();
+          const events = [
+            TestFramework.events.handlerStart("submit", {
+              traceId,
+              componentType: "Button",
+              componentLabel: "OK",
+              perfTs: 100,
+            }),
+          ];
+          const summary = buildTraceSummary(events);
+          assertContains(summary.componentText, "Button", "Should include type");
+          assertContains(summary.componentText, "submit", "Should include event");
+          // No description was provided, so the em-dash separator must not appear.
+          assertTrue(!summary.componentText.includes("—"), "Should not include em-dash without description");
         });
 
         // =========================================================================


### PR DESCRIPTION
## Summary

Lets components contribute a human-readable summary alongside the existing structural identifier in the Inspector trace title. When a `handler:start` event's `eventArgs` contains an object with a string `description` field, the Inspector appends it after an em-dash:

```
XMLUIDndList.DndItems reorder — Toronto moved from position 1 to position 3
```

Convention only — no metadata schema changes, no breaking changes. Components that don't pass a description render exactly as today.

```diff
   const event = preferredStart.eventName || "";
+  const eventArgs = Array.isArray(preferredStart.eventArgs) ? preferredStart.eventArgs : [];
+  const description = eventArgs
+    .map((a) => (a && typeof a === "object" && typeof a.description === "string") ? a.description : null)
+    .find((d) => d);
+
   const parts = [];
   if (type) parts.push(type);
   if (label) parts.push(`"${label}"`);
   else if (uid && uid !== event) parts.push(uid);
   if (event) parts.push(event);
+  if (description) parts.push(`— ${description}`);
   componentText = parts.join(" ");
```

## Motivation

Extension authors currently have no way to surface the *semantic* of a handler invocation in the Inspector summary; the title is purely `<componentType> <eventName>`. Concrete cases where this is unhelpful:

- Drag-and-drop reorders: "DndItems reorder" tells you nothing about *what moved where*.
- Form submits: "Form submit" tells you nothing about *which fields changed*.
- Dialog confirmations: "Dialog confirm" tells you nothing about *what was confirmed*.

The data is often already in `eventArgs` — bundlers and trace consumers can read it — but it's hidden behind the expand chevron. Surfacing a `description` string in the title is a small, opt-in nudge with no schema commitment.

## Producer side

This pairs with [`rdhyee/xmlui-dnd-list#1`](https://github.com/rdhyee/xmlui-dnd-list/pulls) (in flight), where `DndListNative` now passes `{ item, fromIndex, toIndex, description }` as a second arg to `onReorder`. The user's handler still ignores the second arg; the trace records both.

Verified end-to-end locally against current xmlui plus the in-flight build-lib fix ([xmlui-org/xmlui#3426](https://github.com/xmlui-org/xmlui/pull/3426)) — drag-reorder produces traces with `eventArgs[1].description = "Albany, CA moved from position 1 to position 2"` and the Inspector title shows `XMLUIDndList.DndItems reorder — Albany, CA moved from position 1 to position 2`.

## Tests

Adds two in-file tests under `TEST SUITE: Native Event Traces`:

1. `handler:start eventArgs.description appended to title` — confirms the description is surfaced.
2. `handler:start without eventArgs.description omits suffix` — confirms no stray em-dash for components that don't pass a description.

To run: open `xs-diff.html` in a browser and click the **test** button.

## Related follow-up

`xmlui_distill_trace` (in [xmlui-org/xmlui-mcp](https://github.com/xmlui-org/xmlui-mcp)) currently drops non-startup steps when summarizing traces — even though the events are present in the JSON. Worth filing separately so AI tooling can read the same descriptions the Inspector now displays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
