### PR TITLE
Inspector export: three-tier save with Tauri/host-bridge/browser

### DIFF
--- a/GUIDE-APP-DEVELOPER.md
+++ b/GUIDE-APP-DEVELOPER.md
@@ -26,6 +26,55 @@ Then navigate to `/xs-diff.html` in the running app, or embed the inspector in-a
 
 With tracing enabled, every interaction — click, form fill, API call, state change — is captured as a semantic trace event. The inspector shows these as a navigable timeline.
 
+### Exporting trace JSON
+
+The inspector's **Export** button writes the captured trace to JSON. It tries three paths in order, picking whichever works in the current environment:
+
+1. **Tauri direct** — if `window.__TAURI__.core.invoke` is reachable (same-origin Tauri app), it calls a `save_trace_export` command.
+2. **Host-shell bridge** — `postMessage` to `window.top` / `window.parent` and wait for a reply. Useful when the inspector is loaded into a cross-origin iframe (e.g., a Tauri shell that hosts the app over `http://127.0.0.1:<port>` while the parent shell runs on a different origin).
+3. **Browser download** — final fallback; writes a Blob to the user's downloads.
+
+Vanilla browser users always get path 3 (no behavior change). Shell authors who want native filesystem writes implement the small bridge protocol below.
+
+#### Host-bridge protocol
+
+When the inspector wants to export, it sends:
+
+```js
+window.top.postMessage({
+  type: "right-pane",
+  kind: "save-trace-export",
+  requestId: "export-...",   // opaque, echo back in the reply
+  filename: "xs-trace-...json",
+  content: "...",            // JSON string body
+  mimeType: "application/json"
+}, "*");
+```
+
+The host should write the file (typically `~/Downloads/<filename>`) and reply:
+
+```js
+sourceWindow.postMessage({
+  type: "save-trace-export-result",
+  requestId: "export-...",
+  ok: true,
+  path: "/absolute/path/to/written/file"
+}, "*");
+```
+
+Or, on failure:
+
+```js
+sourceWindow.postMessage({
+  type: "save-trace-export-result",
+  requestId: "export-...",
+  ok: false,
+  error: "human-readable message"
+}, "*");
+```
+
+The inspector waits up to 4 seconds for a reply; if none arrives it falls through to the browser download. Implementing this in a Tauri shell takes ~20 lines of Rust + JS dispatch code.
+
 ## Name your components with aria-label
 
 The single most impactful thing you can do for observability (and accessibility) is give components meaningful names via `aria-label`. Without it, traces show the component type but not which instance:

--- a/xs-diff.html
+++ b/xs-diff.html
@@ -81,6 +81,18 @@
         flex-wrap: nowrap;
       }
 
+      .export-status {
+        padding: var(--space-2) var(--space-4);
+        font-size: var(--font-sm);
+        color: var(--color-text-muted);
+        background: var(--color-bg-subtle);
+        border-bottom: 1px solid var(--color-border);
+        text-align: right;
+      }
+      .export-status:empty {
+        display: none;
+      }
+
       .spacer { flex: 1 1 auto; }
 
       label { font-size: var(--font-base); color: var(--color-text); }
@@ -739,8 +751,8 @@
       <button id="clear">Clear</button>
       <button id="test">Test</button>
       <button id="exportJson">Export</button>
-      <span id="exportStatus" style="font-size: var(--font-sm); color: var(--color-text-muted);"></span>
     </div>
+    <div id="exportStatus" class="export-status"></div>
     <div id="diff"></div>
 
     <!-- File Preview Modal -->
@@ -7114,11 +7126,22 @@
         return null;
       }
 
+      let exportStatusTimer = null;
       function setExportStatus(message, isError) {
         const el = document.getElementById("exportStatus");
         if (!el) return;
+        if (exportStatusTimer) {
+          clearTimeout(exportStatusTimer);
+          exportStatusTimer = null;
+        }
         el.textContent = message || "";
         el.style.color = isError ? "var(--color-error)" : "var(--color-text-muted)";
+        if (message) {
+          exportStatusTimer = setTimeout(() => {
+            el.textContent = "";
+            exportStatusTimer = null;
+          }, 4000);
+        }
       }
 
       function flashExportButton() {

--- a/xs-diff.html
+++ b/xs-diff.html
@@ -361,6 +361,17 @@
         100% { background-color: transparent; }
       }
 
+      /* Button flash to confirm export succeeded — the status text is
+         easy to miss, the button itself is what the user just clicked. */
+      @keyframes button-flash-success {
+        0%   { background-color: rgba(34, 197, 94, 0.85); color: #064e3b; }
+        30%  { background-color: rgba(34, 197, 94, 0.85); color: #064e3b; }
+        100% { background-color: transparent; color: inherit; }
+      }
+      #exportJson.flash-success {
+        animation: button-flash-success 1.2s ease-out;
+      }
+
       .highlight-line {
         display: block;
         background: rgba(255, 200, 0, 0.2);
@@ -728,6 +739,7 @@
       <button id="clear">Clear</button>
       <button id="test">Test</button>
       <button id="exportJson">Export</button>
+      <span id="exportStatus" style="font-size: var(--font-sm); color: var(--color-text-muted);"></span>
     </div>
     <div id="diff"></div>
 
@@ -7078,33 +7090,153 @@
         URL.revokeObjectURL(url);
       }
 
-      document.getElementById("exportJson").addEventListener("click", () => {
-        const rawLogs = ((window.parent && window.parent._xsLogs) || []).slice().sort((a, b) => (a.perfTs || a.ts || 0) - (b.perfTs || b.ts || 0));
-        if (rawLogs.length === 0) {
-          alert("No logs found.");
-          return;
-        }
-        const skipKeys = new Set(['_targetInst', '_debugOwner', '_debugSource', 'stateNode', 'nativeEvent', 'view', 'target', 'currentTarget', 'relatedTarget', '__reactFiber$', '__reactProps$']);
-        const stripKeys = new Set(['beforeJson', 'afterJson', 'diffText', 'text']);
-        const jsonEntries = rawLogs.map(entry => {
-          const seen = new WeakSet();
-          return JSON.stringify(entry, (key, value) => {
-            if (value instanceof Node || value instanceof Window) return undefined;
-            if (typeof value === 'function') return undefined;
-            if (skipKeys.has(key)) return undefined;
-            if (stripKeys.has(key)) return undefined;
-            if (key.startsWith('__react')) return undefined;
-            if (key === 'diffPretty' && typeof value === 'string' && value.length > 200) return undefined;
-            if (typeof value === 'object' && value !== null) {
-              if (seen.has(value)) return '[circular]';
-              seen.add(value);
+      // Best-effort lookup of a Tauri invoke handle reachable from this
+      // iframe. xmlui's Inspector usually loads xs-diff.html inside an
+      // iframe-in-iframe, so __TAURI__ may live on parent or top.
+      function getTauriInvoke() {
+        try {
+          if (window.__TAURI__ && window.__TAURI__.core && typeof window.__TAURI__.core.invoke === "function") {
+            return window.__TAURI__.core.invoke.bind(window.__TAURI__.core);
+          }
+        } catch (e) {}
+        try {
+          if (window.parent && window.parent.__TAURI__ && window.parent.__TAURI__.core &&
+              typeof window.parent.__TAURI__.core.invoke === "function") {
+            return window.parent.__TAURI__.core.invoke.bind(window.parent.__TAURI__.core);
+          }
+        } catch (e) {}
+        try {
+          if (window.top && window.top.__TAURI__ && window.top.__TAURI__.core &&
+              typeof window.top.__TAURI__.core.invoke === "function") {
+            return window.top.__TAURI__.core.invoke.bind(window.top.__TAURI__.core);
+          }
+        } catch (e) {}
+        return null;
+      }
+
+      function setExportStatus(message, isError) {
+        const el = document.getElementById("exportStatus");
+        if (!el) return;
+        el.textContent = message || "";
+        el.style.color = isError ? "var(--color-error)" : "var(--color-text-muted)";
+      }
+
+      function flashExportButton() {
+        const btn = document.getElementById("exportJson");
+        if (!btn) return;
+        btn.classList.remove("flash-success");
+        // Force reflow so the animation can re-fire on subsequent clicks.
+        void btn.offsetWidth;
+        btn.classList.add("flash-success");
+      }
+
+      // Host-shell bridge: when xs-diff.html is loaded inside a desktop
+      // shell (Tauri/Electron) on a different origin from the host, the
+      // host can intercept this postMessage and write the file natively.
+      // Protocol documented in GUIDE-APP-DEVELOPER.md.
+      function requestShellExport(filename, content, mimeType) {
+        return new Promise((resolve, reject) => {
+          const hostWindow = window.top && window.top !== window ? window.top : window.parent;
+          if (!hostWindow || typeof hostWindow.postMessage !== "function") {
+            reject(new Error("host window is unavailable"));
+            return;
+          }
+
+          const requestId = `export-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+          const timer = setTimeout(() => {
+            window.removeEventListener("message", onMessage);
+            reject(new Error("host export timed out"));
+          }, 4000);
+
+          function onMessage(event) {
+            const data = event.data;
+            if (!data || data.type !== "save-trace-export-result" || data.requestId !== requestId) {
+              return;
             }
-            return value;
-          });
+            clearTimeout(timer);
+            window.removeEventListener("message", onMessage);
+            if (data.ok) resolve(data.path);
+            else reject(new Error(data.error || "host export failed"));
+          }
+
+          window.addEventListener("message", onMessage);
+          hostWindow.postMessage(
+            {
+              type: "right-pane",
+              kind: "save-trace-export",
+              requestId: requestId,
+              filename: filename,
+              content: content,
+              mimeType: mimeType
+            },
+            "*"
+          );
         });
-        const jsonContent = '[\n  ' + jsonEntries.join(',\n  ') + '\n]';
-        const timestamp = new Date().toISOString().slice(0, 19).replace(/[:-]/g, "");
-        downloadFile(`xs-trace-${timestamp}.json`, jsonContent, "application/json");
+      }
+
+      document.getElementById("exportJson").addEventListener("click", async () => {
+        try {
+          setExportStatus("Preparing export...", false);
+          const rawLogs = ((window.parent && window.parent._xsLogs) || []).slice().sort((a, b) => (a.perfTs || a.ts || 0) - (b.perfTs || b.ts || 0));
+          if (rawLogs.length === 0) {
+            setExportStatus("No logs found.", true);
+            return;
+          }
+          const skipKeys = new Set(['_targetInst', '_debugOwner', '_debugSource', 'stateNode', 'nativeEvent', 'view', 'target', 'currentTarget', 'relatedTarget', '__reactFiber$', '__reactProps$']);
+          const stripKeys = new Set(['beforeJson', 'afterJson', 'diffText', 'text']);
+          const jsonEntries = rawLogs.map(entry => {
+            const seen = new WeakSet();
+            return JSON.stringify(entry, (key, value) => {
+              if (typeof Node !== "undefined" && value instanceof Node) return undefined;
+              if (typeof Window !== "undefined" && value instanceof Window) return undefined;
+              if (typeof value === 'bigint') return value.toString();
+              if (typeof value === 'function') return undefined;
+              if (skipKeys.has(key)) return undefined;
+              if (stripKeys.has(key)) return undefined;
+              if (key.startsWith('__react')) return undefined;
+              if (key === 'diffPretty' && typeof value === 'string' && value.length > 200) return undefined;
+              if (typeof value === 'object' && value !== null) {
+                if (seen.has(value)) return '[circular]';
+                seen.add(value);
+              }
+              return value;
+            });
+          });
+          const jsonContent = '[\n  ' + jsonEntries.join(',\n  ') + '\n]';
+          const timestamp = new Date().toISOString().slice(0, 19).replace(/[:-]/g, "");
+          const filename = `xs-trace-${timestamp}.json`;
+          const invoke = getTauriInvoke();
+
+          if (invoke) {
+            setExportStatus("Saving via Tauri...", false);
+            const savedPath = await invoke("save_trace_export", {
+              filename: filename,
+              content: jsonContent,
+              mimeType: "application/json",
+            });
+            setExportStatus(`Saved to ${savedPath}`, false);
+            flashExportButton();
+            return;
+          }
+
+          setExportStatus("Saving via host bridge...", false);
+          try {
+            const savedPath = await requestShellExport(filename, jsonContent, "application/json");
+            setExportStatus(`Saved to ${savedPath}`, false);
+            flashExportButton();
+            return;
+          } catch (bridgeErr) {
+            console.warn("host bridge export failed, falling back to browser download", bridgeErr);
+          }
+
+          setExportStatus("Downloading via browser...", false);
+          downloadFile(filename, jsonContent, "application/json");
+          setExportStatus(`Download started for ${filename}`, false);
+          flashExportButton();
+        } catch (err) {
+          console.error("exportJson failed", err);
+          setExportStatus(`Export failed: ${err && err.message ? err.message : err}`, true);
+        }
       });
 
       // Handle hash navigation - expand parent trace-group and highlight target


### PR DESCRIPTION
## Summary

The inspector's **Export** button currently writes JSON via the browser's blob-download path only. That works for vanilla browser users, but desktop shells that host the inspector (e.g. xmlui-desktop, which serves the app over a loopback HTTP origin) can't intercept the export to write the file natively.

This PR replaces the click handler with a three-tier graceful fallback:

1. **Tauri direct** — `window.__TAURI__.core.invoke("save_trace_export", ...)` when reachable from the iframe (works through `window`, `parent`, or `top`).
2. **Host-shell bridge** — `postMessage` to `window.top` / `window.parent` and wait for a reply. The shell writes the file natively and replies with the absolute path. Useful when the inspector iframe is cross-origin from the shell (xmlui-desktop's case).
3. **Browser download** — unchanged behavior, the existing fallback.

All additive — vanilla browser users keep seeing browser downloads. Tauri-direct users get native saves with no extra wiring. Cross-origin-iframe Tauri shells get native saves once they implement the small bridge protocol (~20 lines).

UX polish:
- Inline status line next to the button ("Saved to /path/...", "Downloading via browser...", errors).
- 1.2s green flash on the button itself on success — the status text alone is easy to miss.

Documents the bridge protocol in `GUIDE-APP-DEVELOPER.md` so future shell authors don't have to reverse-engineer the message shapes.

## Test plan

- [ ] Open `xs-diff.html` directly in a browser, capture some traces, click Export → file downloads via the browser. Status text shows "Download started for ...". Button flashes green.
- [ ] Embed via `<Inspector />` in an XMLUI app served standalone → same as above (browser fallback).
- [ ] Inside a Tauri shell that registers a `save_trace_export` command → file saved natively. Status text shows "Saved to /path/...". Button flashes green.
- [ ] Inside a cross-origin Tauri shell that implements the postMessage bridge → file saved natively via the bridge. Same status + flash.
- [ ] Click Export with no traces captured → status text "No logs found." in red. No flash.

Generated with [Claude Code](https://claude.com/claude-code)
